### PR TITLE
Multiple forms on one page

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -26,7 +26,7 @@ $config['base_url']	= '';
 | variable so that it is blank.
 |
 */
-$config['index_page'] = 'index.php';
+$config['index_page'] = '';
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/server_testing.php
+++ b/application/controllers/server_testing.php
@@ -12,6 +12,9 @@ class Server_Testing extends MY_Controller {
 		$form = new Ultraform('contact');
 		$this->data['contact_form'] = $form;
 	
+		$form2 = new Ultraform('m_login', 'login');
+		$this->data['login_form'] = $form2;
+		
 		// Set some options on runtime
 		$fish = array(
 				'catfish' => 'African glass catfish',
@@ -22,7 +25,7 @@ class Server_Testing extends MY_Controller {
 				);
 		
 		$form->set_options('fish', $fish);
-		
+
 		if($form->request == 'callback' || $form->request == 'json')
 		{
 			echo $form->ajax();
@@ -32,10 +35,43 @@ class Server_Testing extends MY_Controller {
 			// If form is valid do stuff
 			echo 'Form is valid';
 		}
+
+		if($form2->request == 'callback' || $form2->request == 'json')
+		{
+			echo $form->ajax();
+		}
+		elseif($form2->valid)
+		{
+			// If form is valid do stuff
+			echo 'Form2 is valid';
+		}		
 		
-		if($form->request == 'html')
+		if($form->request == 'html' || $form2->request == 'html')
 		{
 			$this->load->view('server_testing/contact.php', $this->data);
 		}
+	}
+	
+	public function posttest()
+	{
+		// When submitted this should include a POST value for user
+		echo '<form name="input" action="" method="post">
+			Username: <input type="text" name="user">
+			<input type="submit" value="Submit">
+			</form> ';
+	}
+	
+	public function noviewtest()
+	{
+		$this->output->enable_profiler(FALSE);
+		
+		echo '<pre>';
+		print_r($_POST);
+		echo '</pre>';
+		
+		$this->load->library('ultraform');		
+		
+		$form = new Ultraform('contact');
+		echo $form;
 	}
 }

--- a/application/views/server_testing/contact.php
+++ b/application/views/server_testing/contact.php
@@ -1,6 +1,5 @@
 <!doctype html>
 <html>
-	<meta charset='utf-8'> 
 	<head>
 		<title>Contact form test</title>
 		
@@ -20,41 +19,51 @@
 		}
 		</style>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset='utf-8'> 		
 	</head>
 	<body>
 		<div class="container maincontent">
-			<h1>Really bloated contact form</h1>
-	
-			<p>If you would like to contact us, please fill out the following form.</p>
-		
-			<div id="ufo-forms-<?php echo $contact_form->name;?>_error">
-				The following errors were encountered in the form:<br>
-				<ul>
-				</ul>
-			</div>
+			<div class="row">
+				<div class="span8">
+					<h1>Really bloated contact form</h1>
 			
-			<div id="contact_form">
-				<?php echo $contact_form->render('open');?>
-				Please leave your username and password for contacting.
-				<?php echo $contact_form->render('username');?>
-				<?php echo $contact_form->render('password');?>
-				<?php echo $contact_form->render('address');?><br>
-				These are tests for different label sources.
-				<?php echo $contact_form->render('labeltest');?>
-				<?php echo $contact_form->render('label_uit_name');?><br>
-				I like sushi, that is why I will allow you to choose your own... sushi!
-				<?php echo $contact_form->render('sushi');?><br>
-				This is a test for options at runtime.
-				<?php echo $contact_form->render('fish');?><br>
-				<?php echo $contact_form->render('color');?><br>
-				What kind of sauce would you like with the colored sushi?
-				<?php echo $contact_form->render('sauce');?><br>
-				Now would you like to be remembered?
-				<?php echo $contact_form->render('remember_me');?><br>
-				Do you have any remarks you want us to know about?
-				<?php echo $contact_form->render('remarks');?>
-				<?php echo $contact_form->render('submit');?>
-				<?php echo $contact_form->render('close');?>
+					<p>If you would like to contact us, please fill out the following form.</p>
+				
+					<div id="ufo-forms-<?php echo $contact_form->name;?>_error">
+						The following errors were encountered in the form:<br>
+						<ul>
+						</ul>
+					</div>
+					
+					<div id="contact_form">
+						<?php echo $contact_form->render('open');?>
+						Please leave your username and password for contacting.
+						<?php echo $contact_form->render('username');?>
+						<?php echo $contact_form->render('password');?>
+						<?php echo $contact_form->render('address');?><br>
+						These are tests for different label sources.
+						<?php echo $contact_form->render('labeltest');?>
+						<?php echo $contact_form->render('label_uit_name');?><br>
+						I like sushi, that is why I will allow you to choose your own... sushi!
+						<?php echo $contact_form->render('sushi');?><br>
+						This is a test for options at runtime.
+						<?php echo $contact_form->render('fish');?><br>
+						<?php echo $contact_form->render('color');?><br>
+						What kind of sauce would you like with the colored sushi?
+						<?php echo $contact_form->render('sauce');?><br>
+						Now would you like to be remembered?
+						<?php echo $contact_form->render('remember_me');?><br>
+						Do you have any remarks you want us to know about?
+						<?php echo $contact_form->render('remarks');?>
+						<?php echo $contact_form->render('submit');?>
+						<?php echo $contact_form->render('close');?>
+					</div>
+				</div>
+				<div class="span4">
+					<h1>Login form</h1>
+					<p>Please login and stuff</p>
+					<?php echo $login_form; ?>
+				</div>
 			</div>
 		</div>
 


### PR DESCRIPTION
Ultraform should now be able to determine what form is being sent on pages with more then one form.

Element objects now have a `$name` and a `$uniquename`. The uniquename is what is used in templates, the `$name` is what is used in the library itself as a identified. When the client sends back a POST request Ultraform will first determine if it is for that instance of Ultraform. and if it is rewrite the uniquenames back to normal names for processing.

Thing to think of in the future is if we want to set the name on runtime that Ultraform also updates the `$uniquename` when rendering.

Note: This thoroughly messes up the client because the HTML output is changed. Needs a fix.
# 

Removed index.php from config.php to clean up URLs.
