### PR TITLE
Client radiobuttongroup

### DIFF
--- a/application/controllers/client_testing.php
+++ b/application/controllers/client_testing.php
@@ -188,7 +188,7 @@ class Client_Testing extends CI_Controller {
 					array(
 						'name'  => 'color',
 						'label' => 'Color',
-						'value' => '',
+						'value' => 'yellow',
 						'rules' => 'required|matches[alpha]',
 						'options' => array(
 							'yellow' => 'yellow',

--- a/application/views/client_testing/temp.php
+++ b/application/views/client_testing/temp.php
@@ -274,7 +274,7 @@ input[type='text'].required, textarea.required {
 	<h2 id="qunit-userAgent"></h2>
 	<ol id="qunit-tests">
 
-<div id="ufo-forms-33_error">
+<div id="ufo-forms-33_error" style="display:none">
 The following errors were encountered in the form:<br>
 <ul>
 </ul>
@@ -381,7 +381,7 @@ The following errors were encountered in the form:<br>
 	</div>
 	<div>
 		<label for="color">color: </label>
-			<input type="radio" value="yellow" name="color" id="ufo-forms-33-color-yellow">yellow 
+			<input type="radio" value="yellow" name="color" id="ufo-forms-33-color-yellow" checked>yellow 
 			<input type="radio" value="green" name="color" id="ufo-forms-33-color-green">green 
 			<input type="radio" value="blue" name="color" id="ufo-forms-33-color-blue">blue 
 			<input type="radio" value="purple" name="color" id="ufo-forms-33-color-purple">purple 
@@ -444,11 +444,11 @@ Ultraform.beforeExtend.ElementModel = function(obj) {
 	obj.initializeVisibility = function() {
 		// get the model that the visibility depends on
 		var dependOnName = showWhenValid[this.get('name')];
-		var dependOnModel = this.parentCollection.findWhere({name: dependOnName});
+		var dependOnModel = this.collection.findWhere({name: dependOnName});
 		
 		if (_.isUndefined(dependOnModel)) {
 			// dependOnModel does not yet exist, wait for it to be added and then start listening to it
-			this.listenTo(this.parentCollection, 'add', function(addedModel) {
+			this.listenTo(this.collection, 'add', function(addedModel) {
 				if (addedModel.get('name') == dependOnName) {
 					// listen to validation changes and visibility changes on the depend-on model
 					this.listenTo(addedModel, 'change', this.handleVisibility);


### PR DESCRIPTION
Radiobuttons can now use validations.

This will become useful when the Submit-button starts validating the whole form (which doesn't work yet).
Until then, you can test this functionality by setting `matches[otherfield]` as validation rule and see that that validation works.

This also contains preliminary work to get select and checkbox working (they might even work but I didn't test).

I used one model+view for every radiobutton. This might seem excessive, but this will make it easier to add radio-buttons and select-options using a template on the fly. I also seems slightly cleaner.
