### PR TITLE
Fixes a warning that appears if a JSON data file is empty.

### DIFF
--- a/application/libraries/Ultraform.php
+++ b/application/libraries/Ultraform.php
@@ -131,6 +131,14 @@ class Ultraform {
 		// Decode the JSON, return objects
 		$data = json_decode($data);
 		
+		// See if the form is empty
+		if(empty($data))
+		{
+			//TODO: Proper error handling
+			echo 'Form ' . $this->name . ' was empty.';
+			exit;
+		}
+		
 		// Try to load a language file for this form
 		if(file_exists($this->CI->input->server('DOCUMENT_ROOT') . '/' . APPPATH . 'language/' . $this->CI->config->item('language') . '/ufo_' . $this->source . '_lang.php'))
 		{


### PR DESCRIPTION
If you leave the JSON data file empty PHP will throw a warning.

Now it will stop loading the page. Note: Will have to look into proper error handling for Ultraform soon.
