### PR TITLE
Export() now also returns the placeholder for use in #97.

### DIFF
--- a/application/libraries/Ultraform.php
+++ b/application/libraries/Ultraform.php
@@ -577,6 +577,7 @@ class Element {
 		$export['label'] = $this->label;
 		$export['value'] = $this->value;
 		$export['rules'] = $this->rules;
+		$export['placeholder'] = $this->placeholder;
 		
 		// Add options if this element has them
 		if($this->options != NULL)


### PR DESCRIPTION
Export() now also returns the placeholder for use in #97.
