### PR TITLE
Turned off profiler on ajax() calls.

### DIFF
--- a/application/libraries/Ultraform.php
+++ b/application/libraries/Ultraform.php
@@ -178,6 +178,9 @@ class Ultraform {
 	 */
 	public function ajax()
 	{
+		// Turn off the profiler if it is on
+		$this->CI->output->enable_profiler(FALSE);
+		
 		if($this->request == 'callback')
 		{
 			// Do callback


### PR DESCRIPTION
Please look at the AJAX feedback for validating the remarks field of server_testing some more. This doesn't seem correct yet. Seems it gives it twice, and does not display the error.
